### PR TITLE
AD-HOC feat (Travis): Add Travis integration, tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,18 @@
+---
+services: docker
+
+env:
+  - distro: ubuntu1604
+    playbook: test.yml
+
+script:
+  # Configure test script so we can run extra tests after playbook is run.
+  - export container_id=$(date +%s)
+  - export cleanup=false
+
+  # Download test shim.
+  - wget -O ${PWD}/tests/test.sh https://gist.githubusercontent.com/geerlingguy/73ef1e5ee45d8694570f334be385e181/raw/
+  - chmod +x ${PWD}/tests/test.sh
+
+  # Run tests.
+  - ${PWD}/tests/test.sh

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -1,5 +1,4 @@
 ---
-- hosts: localhost
-  remote_user: root
+- hosts: all
   roles:
-    - .
+    - role_under_test


### PR DESCRIPTION
This commit adds test integration, following the pattern defined by
Jeff Geerling.

It would also be possible to do this with `ansible-test`, but the author
is not as familiar with this.