### PR TITLE
AD-HOC fix (configuration): Reload configuration on change

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,2 +1,5 @@
 ---
-# handlers file for .
+- name: "reload td-agent"
+  service:
+    name: "td-agent-bit"
+    state: "restarted"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -25,6 +25,7 @@
   template:
     src: "etc/td-agent-bit/td-agent-bit.conf.j2"
     dest: "/etc/td-agent-bit/td-agent-bit.conf"
+  notify: "reload td-agent"
 
 - name: "Start service td-agent-bit, if not running"
   service:


### PR DESCRIPTION
Currently there is a problem in which the configuration for the
`td-agent-bit` daemon will not be reloaded when it is changed. This
means for the *first* ansible task all things will appear to be correct,
but for *subsequent* ansible tasks the configuration will not apply to
the daemon.

This commit introduces reloading of the daemon dynamically based on
whether this configuration has changed, using ansibles "handler"
primitives.