### PR TITLE
Use distribution in repo url

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
 
 - name: "Ensure the package repository is up to date"
   apt_repository:
-    repo: "deb https://packages.fluentbit.io/ubuntu/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main"
+    repo: "deb https://packages.fluentbit.io/{{ ansible_distribution|lower }}/{{ ansible_distribution_release }} {{ ansible_distribution_release }} main"
     state: "present"
 
 - name: "Update repositories cache and install td-agent-bit"


### PR DESCRIPTION
Ansible variable instead of hardcoded platform allows using this role on Debian.